### PR TITLE
Ignore missing user keys

### DIFF
--- a/set_up_authorized_keys.rb
+++ b/set_up_authorized_keys.rb
@@ -10,12 +10,16 @@ end
 gh_users = (ENV['GITHUB_USER'] || '').split(',')
 
 gh_keys = if gh_users.size > 0
-  gh_users.map { |u|
-    open("https://github.com/#{u}.keys").read
-  }.join("\n")
-else
-  nil
-end
+            gh_users.map do |u|
+              key_url = "https://github.com/#{u}.keys"
+              begin
+                open(key_url).read
+              rescue OpenURI::HTTPError => e
+                puts "[WARN]: #{e.message} while opening #{key_url}, #{u}'s key is ignored'"
+                nil
+              end
+            end.select.to_a.join("\n")
+          end
 
 key_files = Dir.glob('/keys/**')
 keys = if key_files.size > 0

--- a/set_up_authorized_keys.rb
+++ b/set_up_authorized_keys.rb
@@ -15,10 +15,10 @@ gh_keys = if gh_users.size > 0
               begin
                 open(key_url).read
               rescue OpenURI::HTTPError => e
-                puts "[WARN]: #{e.message} while opening #{key_url}, #{u}'s key is ignored'"
+                warn "[WARN]: #{e.message} while opening #{key_url}, #{u}'s key is ignored'"
                 nil
               end
-            end.select.to_a.join("\n")
+            end.compact.join("\n")
           end
 
 key_files = Dir.glob('/keys/**')


### PR DESCRIPTION
# Overview

- 誰かがユーザ名間違ってるとプロセスが死んじゃう
- 何が原因でコケたかLogでわからない

# Changes

- 鍵が見えないユーザは無視する
- 鍵が取れない旨のエラーメッセージ吐く

## Before
```
Setting up authorized_keys...                                                                                                                                                                                                                                    │
/usr/local/lib/ruby/2.5.0/open-uri.rb:377:in `open_http': 404 Not Found (OpenURI::HTTPError)
    from /usr/local/lib/ruby/2.5.0/open-uri.rb:755:in `buffer_open'
    from /usr/local/lib/ruby/2.5.0/open-uri.rb:226:in `block in open_loop'
    from /usr/local/lib/ruby/2.5.0/open-uri.rb:224:in `catch'
    from /usr/local/lib/ruby/2.5.0/open-uri.rb:224:in `open_loop'
    from /usr/local/lib/ruby/2.5.0/open-uri.rb:165:in `open_uri'
    from /usr/local/lib/ruby/2.5.0/open-uri.rb:735:in `open'
    from /usr/local/lib/ruby/2.5.0/open-uri.rb:35:in `open'
    from set_up_authorized_keys.rb:14:in `block in <main>'
    from set_up_authorized_keys.rb:13:in `map'
    from set_up_authorized_keys.rb:13:in `<main>'
```


## After

```
[WARN]: 404 Not Found while opening https://github.com/XXX.keys, XXX's key is ignored.'
```