### PR TITLE
open() -> URI.open()

### DIFF
--- a/set_up_authorized_keys.rb
+++ b/set_up_authorized_keys.rb
@@ -9,11 +9,11 @@ end
 
 gh_users = (ENV['GITHUB_USER'] || '').split(',')
 
-gh_keys = if gh_users.size > 0
+gh_keys = unless gh_users.empty?
             gh_users.map do |u|
               key_url = "https://github.com/#{u}.keys"
               begin
-                open(key_url).read
+                URI.open(key_url).read
               rescue OpenURI::HTTPError => e
                 warn "[WARN]: #{e.message} while opening #{key_url}, #{u}'s key is ignored'"
                 nil
@@ -22,13 +22,11 @@ gh_keys = if gh_users.size > 0
           end
 
 key_files = Dir.glob('/keys/**')
-keys = if key_files.size > 0
-  key_files.map { |f|
-    open(f).read
-  }.join("\n")
-else
-  nil
-end
+keys = unless key_files.empty?
+        key_files.map do |f|
+          open(f).read
+        end.join("\n")
+       end
 
 open(AUTHORIZED_KEYS_PATH, 'a') do |io|
   if keys


### PR DESCRIPTION
# Overview

`open-uri` does not overrides Kernel#open anymore in Ruby3,
so this image raises an error:

```sh
$ GITHUB_USER=ryonkmr ruby ./set_up_authorized_keys.rb                                              (kubernetes.400f.jp/default)
./set_up_authorized_keys.rb:16:in `initialize': No such file or directory @ rb_sysopen - https://github.com/ryonkmr.keys (Errno::ENOENT)
        from ./set_up_authorized_keys.rb:16:in `open'
        from ./set_up_authorized_keys.rb:16:in `block in <main>'
        from ./set_up_authorized_keys.rb:13:in `map'
        from ./set_up_authorized_keys.rb:13:in `<main>'
```

use URI#open instead.